### PR TITLE
TestBox run should use webroot when resolving testbox location in ensureTestBox()

### DIFF
--- a/commands/testbox/run.cfc
+++ b/commands/testbox/run.cfc
@@ -425,9 +425,12 @@ component {
 		var testBoxPath = variables.moduleConfig.path & "/testbox";
 		var modulePath  = variables.moduleConfig.path;
 
+		var serverDetails = variables.serverService.resolveServerDetails( {} );
+		var serverInfo    = serverDetails.serverInfo;
+		
 		// Check if installed locally
 		if ( arguments.testboxUseLocal ) {
-			testBoxPath = resolvePath( "testbox" );
+			testBoxPath = resolvePath( "testbox", "#serverInfo.webroot#" );
 		}
 
 		if ( !directoryExists( testBoxPath ) ) {


### PR DESCRIPTION
# Description

Currently, if your testbox folder is not in the current folder where your server.json lives, ie, a subfolder like /test-harness or /app the ensureTestBox() function fails, and then installs testbox into the testbox-cli folder.

In CI, this testbox-cli folder never has a testbox in it, because its built from an image, so this means every time we run tests, it installs testbox over and over and over again.

This fix users the server info to pass the webroot of the current server to the resolvePath() command, to ensure we look for testbox in the webroot. 

Improvement: Maybe we look in the current folder, and in the webroot?

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Issues

All PRs must have an accompanied issue. Please make sure you created it and linked it here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
